### PR TITLE
Make tokenization respect escaped quotes.

### DIFF
--- a/process_sql.py
+++ b/process_sql.py
@@ -112,11 +112,24 @@ def get_schema_from_json(fpath):
 
     return schema
 
+def find_quoted_strings(text: str) -> List[int]:
+    quote_idxs = []
+    idx = 0
+    escaped = False
+    while idx < len(text):
+        if escaped:
+            idx, escaped = idx + 1, False
+        c = text[idx]
+        if c == "\\":
+            escaped = True
+        elif c == "\'" or c == "\"":
+            quote_idxs.append(idx)
+        idx += 1
+    return quote_idxs
+
 
 def tokenize(string):
-    string = str(string)
-    string = string.replace("\'", "\"")  # ensures all string values wrapped by "" problem??
-    quote_idxs = [idx for idx, char in enumerate(string) if char == '"']
+    quote_idxs = find_quoted_strings(string)
     assert len(quote_idxs) % 2 == 0, "Unexpected quote"
 
     # keep string value as token


### PR DESCRIPTION
Note: SQL usually use single quotes for strings but the old implementation allowed both single and double quoted string as well as a single quoted string to end with a double quote.

This implementation keeps this behavior but allows for quotes to be escaped.

For example strings like `"O\'Reilly"` won't cause assertion failure and will be tokenized correctly.